### PR TITLE
Correct missing values on Living Zephyr

### DIFF
--- a/sorted/36-companion.part
+++ b/sorted/36-companion.part
@@ -2,14 +2,14 @@
 <?xml-stylesheet type="text/xsl" href="/D20Rules.xslt"?>
 <D20Rules game-system="D&amp;D4E">
   <UpdateInfo>
-    <Version>1.14</Version>
+    <Version>1.15</Version>
     <Filename>36-companion.part</Filename>
     <PartAddress>https://cbloader.vorpald20.com/sorted/36-companion.part</PartAddress>
     <VersionAddress>https://cbloader.vorpald20.com/sorted/36-companion.txt</VersionAddress>
   <V2Address>https://cbloader.vorpald20.com/versions2.txt</V2Address></UpdateInfo>
   <!-- Companion Characters -->
-  <!-- 36-companion.part, version 1.12 -->
-  <!-- Original release: 25-July-2011; Last modified: 27-February-2013 -->
+  <!-- 36-companion.part, version 1.15 -->
+  <!-- Original release: 25-July-2011; Last modified: 18-June-2026 -->
   <!-- Test compiled with CBLoader build V1.3.0 -->
   <!-- This part file belongs to the July 2011 reorganization of data files. -->
   <!-- Special thanks to the entire community for handling the materials. -->
@@ -28,6 +28,7 @@
  Updated 27-February-2013 Added the Famaliar (Bellavous, Bound Quasit) from ELTU3 The Way of All Flesh
  Updated 17-February-2022 Updated fiddling grig and coure attendant to Heroes of the Feywild stats
  Updated 4-June-2024 Added Eberron Campaign Guide mounts.
+ Updated 18-June-2026 Corrected missing values on Living Zephyr
 </Changelog>
   <!-- Section: Required Gear Tweaks -->
 
@@ -31200,8 +31201,8 @@ STANDARD
 m Animal Attack F At-Will
 Attack: Melee 1 (one creature); your level + 5 vs. AC
 Hit: 1d10 + your Wisdom modifier damage, and the zephyr can slide the target 1 square.
-Level 13: + your Wisdom modifier damage.
-Level 23: + your Wisdom modifier damage.
+Level 13: 1d10 + 3 + your Wisdom modifier damage.
+Level 23: 2d10 + 5 + your Wisdom modifier damage.
 
 Str: 12	Dex: 20	Wis: 14
 Con: 17	Int: 3	Cha: 7
@@ -31220,8 +31221,8 @@ AC 14, Fortitude 13, Reflex 14, Will 13	 </specific>
   <specific name="Debris Cloud (Aura 2)"> The aura is lightly obscured to enemies. </specific>
   <specific name="Animal Attack (At-Will)"> Attack: Melee 1 (one creature); your level + 5 vs. AC
 Hit: 1d10 + your Wisdom modifier damage, and the zephyr can slide the target 1 square.
-Level 13: + your Wisdom modifier damage.
-Level 23: + your Wisdom modifier damage. </specific>
+Level 13: 1d10 + 3 + your Wisdom modifier damage.
+Level 23: 2d10 + 5 + your Wisdom modifier damage. </specific>
   <specific name="Ability Scores"> Str: 12  Dex: 20  Wis: 14
 Con: 17  Int: 3  Cha: 7 </specific>
 </RulesElement>


### PR DESCRIPTION
Living Zephyr is missing its level upscale damage dice (and extra bonus) entries on its attack.